### PR TITLE
Fix CreateVirtualMachine for Generation 1 VMs

### DIFF
--- a/hyperv/ssh/driver_ps_ssh.go
+++ b/hyperv/ssh/driver_ps_ssh.go
@@ -455,7 +455,7 @@ if ($harddrivePath){
 	New-VM -Name $vmName -Path $path -MemoryStartupBytes $memoryStartupBytes -VHDPath $vhdPath -SwitchName $switchName
 } else {
 	New-VM -Name $vmName -Path $path -MemoryStartupBytes $memoryStartupBytes -NewVHDPath $vhdPath -NewVHDSizeBytes $newVHDSizeBytes -SwitchName $switchName
-} } "%s" "%s" "%s" "%s" %d %d "%s" "%s"`, vmName, path, harddrivePath, vhdRoot, ram, diskSize, switchName, strconv.FormatBool(diffDisks)))
+} } CreateVMachine "%s" "%s" "%s" "%s" %d %d "%s" "%s"`, vmName, path, harddrivePath, vhdRoot, ram, diskSize, switchName, strconv.FormatBool(diffDisks)))
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
I wasn't able to use this plugin to create a Generation 1 VM.  The code for the Generation 1 path was not actually invoking the CreateVMachine function.